### PR TITLE
CSV table view rows can now be moved, dragged & dropped

### DIFF
--- a/Table Tool UI Tests/Document_UI_Tests.m
+++ b/Table Tool UI Tests/Document_UI_Tests.m
@@ -1,0 +1,213 @@
+//
+//  Document_UI_Tests.m
+//  Table Tool
+//
+//  Created by Martin Köhler on 18.06.17.
+//  Copyright © 2017 Egger Apps. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "NSFileHandle+TempFile.h"
+
+@interface DocumentTests : XCTestCase
+{
+    XCUIApplication *app;
+    NSSpeechSynthesizer *speechSynthesizer;
+}
+@end
+
+@implementation DocumentTests
+
+- (void)setUp {
+    [super setUp];
+    
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+    
+    // In UI tests it is usually best to stop immediately when a failure occurs.
+    self.continueAfterFailure = NO;
+    // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+    
+    app = [[XCUIApplication alloc] init];
+    [app launch];
+    
+    for (NSString *voiceIdentifier in [NSSpeechSynthesizer availableVoices]) {
+        NSString *voiceLocaleIdentifier = [[NSSpeechSynthesizer attributesForVoice:voiceIdentifier] objectForKey:NSVoiceLocaleIdentifier];
+        NSLog(@"%@ speaks %@", voiceIdentifier, voiceLocaleIdentifier);
+        
+        if ([voiceLocaleIdentifier containsString:@"en_US"]) {
+            NSLog(@"Using, %@ speaks %@", voiceIdentifier, voiceLocaleIdentifier);
+            
+            speechSynthesizer = [[NSSpeechSynthesizer alloc] initWithVoice:voiceIdentifier];
+            break;
+        }
+    }
+    
+    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run.
+    // The setUp method is a good place to do this.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+    
+    [self removeTempFiles];
+}
+
+- (void)speak:(NSString *)text
+{
+    [self waitUntilFinishedSpeaking];
+    [speechSynthesizer startSpeakingString:text];
+}
+
+- (void)waitUntilFinishedSpeaking
+{
+    // NOTE: potentially better use async delegate, but to keep it simple as it's just a test case, for now polling every second
+    while ([NSSpeechSynthesizer isAnyApplicationSpeaking]) {
+        [NSThread sleepForTimeInterval:1.0];
+    }
+}
+
+- (void)closeAllDocuments
+{
+    [self speak:@"Closing all documents from previous sessions"];
+    
+    XCUIElementQuery *menuBarsQuery = app.menuBars;
+    XCUIElement *fileMenuBarItem = menuBarsQuery.menuBarItems[@"File"];
+    [fileMenuBarItem click];
+    
+    XCUIElement *closeMenuItem = menuBarsQuery.menuItems[@"Close"];
+    while ([closeMenuItem isEnabled]) {
+        [closeMenuItem click];
+        [fileMenuBarItem click];
+    }
+}
+
+- (void)openDocumentAtPath:(NSString *)absoluteDocumentPath
+{
+    [self speak:@"Opening Test Document"];
+    
+    XCUIElementQuery *menuBarsQuery = app.menuBars;
+    XCUIElement *openMenuItem = menuBarsQuery.menuItems[@"Open…"];
+    [openMenuItem click];
+    
+    XCUIElement *openDialog = app.dialogs[@"Open"];
+    NSString *gKey = @"g";
+    XCUIKeyModifierFlags cmdAndShiftModifierFlags = XCUIKeyModifierCommand | XCUIKeyModifierShift;
+    [openDialog typeKey:gKey modifierFlags:cmdAndShiftModifierFlags];
+    
+    XCUIElementQuery *textFieldsQuery = openDialog.sheets.textFields;
+    XCUIElement *pathTextField = [textFieldsQuery element];
+    
+    [pathTextField typeText:absoluteDocumentPath];
+    [pathTextField typeText:@"\n"];
+    
+    [openDialog typeText:@"\n"]; // confirm open of file
+}
+
+- (void)clickToolbarItemWithIdentifier:(NSString *)toolbarItemID
+                      inDocumentWindow:(XCUIElement *)docWindow
+{
+    [self speak:[NSString stringWithFormat:@"Clicking toolbar item '%@'",toolbarItemID,nil]];
+    
+    XCUIElementQuery *toolbarGroupQuery = [docWindow.toolbars.groups containingType:XCUIElementTypeStaticText identifier:toolbarItemID];
+    XCUIElement *toolbarItemButton = [[toolbarGroupQuery descendantsMatchingType:XCUIElementTypeButton] elementBoundByIndex:1];
+    [toolbarItemButton click];
+}
+
+- (void)revertToActionMatchingPredicateWithFormat:(NSString *)predicateFormat
+                                 inDocumentWindow:(XCUIElement *)docWindow
+{
+    [self speak:@"Reverting document"];
+    
+    XCUIElementQuery *menuBarsQuery = app.menuBars;
+    [menuBarsQuery.menuBarItems[@"File"] click];
+    
+    XCUIElement *revertMenuItem = menuBarsQuery.menuItems[@"Revert To"];
+    [revertMenuItem click];
+    
+    // NOTE: substring search necessary, because the menu item will be something like .menuItems[@"Last Opened \U2014 Heute, 12:35"]
+    XCUIElement *revertToLastOpenedMenuItem = [revertMenuItem.menuItems elementMatchingPredicate:[NSPredicate predicateWithFormat:predicateFormat]];
+    [revertToLastOpenedMenuItem click];
+    
+    [docWindow.sheets[@"alert"].buttons[@"Revert"] click];
+}
+
+- (void)assertTableCellValue:(NSString *)expectedValue
+                         row:(NSUInteger)row
+                      column:(NSUInteger)column
+            inDocumentWindow:(XCUIElement *)docWindow
+{
+    [self speak:[NSString stringWithFormat:@"Asserting table cell in row %ld, column %ld to have the expected value '%@'", row, column, expectedValue, nil]];
+    
+    XCUIElement *textField = [[[[docWindow.tables childrenMatchingType:XCUIElementTypeTableRow] elementBoundByIndex:0] childrenMatchingType:XCUIElementTypeTextField] elementBoundByIndex:0];
+    [textField click];
+    
+    [self waitUntilFinishedSpeaking];
+    XCTAssertEqualObjects(expectedValue, [textField value]);
+}
+
+-(void)removeTempFiles
+{
+    NSString *tmpDirectory = NSTemporaryDirectory();
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSError *error = nil;
+    NSArray *cacheFiles = [fileManager contentsOfDirectoryAtPath:tmpDirectory error:&error];
+    for (NSString *file in cacheFiles) {
+        error = nil;
+        [fileManager removeItemAtPath:[tmpDirectory stringByAppendingPathComponent:file] error:&error];
+    }
+}
+
+- (void)testRestoreDocumentWithTableHeaderDetection
+{
+    //
+    // This test case is a regression test which reproduces a defect (2017.06.18)
+    //
+    // Defect Summary: Autodetected table header is lost after restoring an older version of the document
+    //
+    // Steps to reproduce:
+    //     (1) open a CSV with an autodetectable table header
+    //     (2) Assert: table header is detected
+    //     (3) append a table row without saving the document
+    //     (4) click main menu "File" > Restore to the opened version
+    //     (5) Assert: table header is detected   (Defect: this assertion failed!)
+    //
+    
+    [self closeAllDocuments];
+    
+    NSString *testData = @"header1,header2\n"
+                          "1,2";
+    
+    NSMutableString *outPath = [NSMutableString string];
+    NSError *error = nil;
+    NSString *testCSVFileName = @"test-CSV-with-header";
+    NSString *extension = @"csv";
+    NSFileHandle *tmpFile = [NSFileHandle tempFileForTestClass:[self className]
+                                                      selector:NSStringFromSelector(_cmd)
+                                      fileNameWithoutExtension:testCSVFileName
+                                                     extension:extension
+                                                       getPath:outPath
+                                                         error:&error];
+    XCTAssertNil(error);
+    if (error != nil) {
+        return; // test failure
+    }
+    
+    [tmpFile truncateFileAtOffset:0];
+    [tmpFile writeData:[testData dataUsingEncoding:NSUTF8StringEncoding]];
+    [tmpFile closeFile];
+        
+    [self openDocumentAtPath:outPath];
+
+    NSString *windowTitle = [outPath lastPathComponent];
+    XCUIElement *docWindow = app.windows[windowTitle];
+    
+    [self clickToolbarItemWithIdentifier:@"Add Row" inDocumentWindow:docWindow];
+    
+    [self revertToActionMatchingPredicateWithFormat:@"title contains[cd] \"Last Opened\"" inDocumentWindow:docWindow];
+    
+    // NOTE: if the header detection would have worked, row cell (0, 0) must be '1', but not 'header1'
+    [self assertTableCellValue:@"1" row:0 column:0 inDocumentWindow:docWindow];
+}
+
+@end

--- a/Table Tool UI Tests/Info.plist
+++ b/Table Tool UI Tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Table Tool UI Tests/NSFileHandle+TempFile.h
+++ b/Table Tool UI Tests/NSFileHandle+TempFile.h
@@ -1,0 +1,20 @@
+//
+//  NSFileHandle+TempFile.h
+//  Table Tool
+//
+//  Created by Martin Köhler on 18.06.17.
+//  Copyright © 2017 Egger Apps. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSFileHandle (TempFile)
+
++ (NSFileHandle * _Nullable)tempFileForTestClass:(NSString * _Nonnull)className
+                                        selector:(NSString * _Nonnull)selector
+                        fileNameWithoutExtension:(NSString * _Nonnull)fileName
+                                       extension:(NSString * _Nonnull)extension
+                                         getPath:(NSMutableString * _Nonnull)outPath
+                                           error:(NSError * _Nullable __autoreleasing * _Nullable)error;
+
+@end

--- a/Table Tool UI Tests/NSFileHandle+TempFile.m
+++ b/Table Tool UI Tests/NSFileHandle+TempFile.m
@@ -1,0 +1,53 @@
+//
+//  NSFileHandle+TempFile.m
+//  Table Tool
+//
+//  Created by Martin Köhler on 18.06.17.
+//  Copyright © 2017 Egger Apps. All rights reserved.
+//
+
+#import "NSFileHandle+TempFile.h"
+
+@implementation NSFileHandle (TempFile)
+
++ (NSFileHandle * _Nullable)tempFileForTestClass:(NSString * _Nonnull)className
+                                        selector:(NSString * _Nonnull)selector
+                        fileNameWithoutExtension:(NSString * _Nonnull)fileName
+                                       extension:(NSString * _Nonnull)extension
+                                         getPath:(NSMutableString * _Nonnull)outPath
+                                           error:(NSError * _Nullable __autoreleasing * _Nullable)error
+{
+    NSString *containerDir = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@",className,selector,nil]];
+    
+    [[NSFileManager defaultManager] createDirectoryAtPath:containerDir withIntermediateDirectories:YES attributes:nil error:error];
+    
+    NSString *fileNameTemplate = [NSString stringWithFormat:@"%@.XXXX.%@",fileName,extension,nil];
+    
+    NSString *path = [containerDir stringByAppendingPathComponent:fileNameTemplate];
+    
+    const char *templateCString = [path fileSystemRepresentation];
+
+    char *tempFileCString = (char *)malloc(strlen(templateCString) + 1);
+    strcpy(tempFileCString, templateCString);
+    
+    int fileDescriptor = mkstemps(tempFileCString, (int)([extension length] + 1));
+
+    if (fileDescriptor == -1) {
+        free(tempFileCString);
+        
+        *error = [NSError errorWithDomain:NSPOSIXErrorDomain code:errno userInfo:nil];
+        return nil;
+    }
+    
+    NSString *tempPath = [[NSFileManager defaultManager] stringWithFileSystemRepresentation:tempFileCString
+                                                                                     length:strlen(tempFileCString)];
+    
+    free(tempFileCString);
+
+    
+    [outPath setString:tempPath];
+    
+    return [[NSFileHandle alloc] initWithFileDescriptor:fileDescriptor closeOnDealloc:YES];
+}
+
+@end

--- a/Table Tool.xcodeproj/project.pbxproj
+++ b/Table Tool.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5B338F741EF03D8000D40406 /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B338F731EF03D8000D40406 /* Constants.m */; };
 		AA58C3F91CFC4DC600106C66 /* TTFormatViewControllerAccessory.xib in Resources */ = {isa = PBXBuildFile; fileRef = AA58C3F81CFC4DC600106C66 /* TTFormatViewControllerAccessory.xib */; };
 		AAB016721D057426005E3F7A /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = AAB016711D057426005E3F7A /* Credits.rtf */; };
 		E109B48B1B5E4598005B4959 /* CSVConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = E109B48A1B5E4598005B4959 /* CSVConfiguration.m */; };
@@ -43,6 +44,8 @@
 
 /* Begin PBXFileReference section */
 		36007A091D083BA000898043 /* Table Tool.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "Table Tool.entitlements"; sourceTree = "<group>"; };
+		5B338F721EF03D8000D40406 /* Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
+		5B338F731EF03D8000D40406 /* Constants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Constants.m; sourceTree = "<group>"; };
 		AA41D3431CF2E7CE00CB3E7D /* Table Tool-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Table Tool-Bridging-Header.h"; sourceTree = "<group>"; };
 		AA58C3F81CFC4DC600106C66 /* TTFormatViewControllerAccessory.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TTFormatViewControllerAccessory.xib; sourceTree = "<group>"; };
 		AAB016711D057426005E3F7A /* Credits.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
@@ -120,6 +123,8 @@
 		E1CC84DD1B4A5F2A00ED8314 /* Table Tool */ = {
 			isa = PBXGroup;
 			children = (
+				5B338F721EF03D8000D40406 /* Constants.h */,
+				5B338F731EF03D8000D40406 /* Constants.m */,
 				36007A091D083BA000898043 /* Table Tool.entitlements */,
 				E1CEF8811B6B63380083B957 /* ToolbarIcons.h */,
 				E1CEF8821B6B63380083B957 /* ToolbarIcons.m */,
@@ -296,6 +301,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5B338F741EF03D8000D40406 /* Constants.m in Sources */,
 				E1CEF8831B6B63380083B957 /* ToolbarIcons.m in Sources */,
 				E1CC84E71B4A5F2A00ED8314 /* Document.m in Sources */,
 				E16BDFCE1B4E74960024F0BD /* CSVReader.m in Sources */,

--- a/Table Tool.xcodeproj/project.pbxproj
+++ b/Table Tool.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		5B338F741EF03D8000D40406 /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B338F731EF03D8000D40406 /* Constants.m */; };
+		5BBE9AF01EF676D100FB2806 /* Document_UI_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BBE9AEF1EF676D100FB2806 /* Document_UI_Tests.m */; };
+		5BCD58251EF67D0F00A7382C /* NSFileHandle+TempFile.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BCD58241EF67D0F00A7382C /* NSFileHandle+TempFile.m */; };
 		AA58C3F91CFC4DC600106C66 /* TTFormatViewControllerAccessory.xib in Resources */ = {isa = PBXBuildFile; fileRef = AA58C3F81CFC4DC600106C66 /* TTFormatViewControllerAccessory.xib */; };
 		AAB016721D057426005E3F7A /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = AAB016711D057426005E3F7A /* Credits.rtf */; };
 		E109B48B1B5E4598005B4959 /* CSVConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = E109B48A1B5E4598005B4959 /* CSVConfiguration.m */; };
@@ -33,6 +35,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		5BBE9AF21EF676D100FB2806 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E1CC84D31B4A5F2A00ED8314 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E1CC84DA1B4A5F2A00ED8314;
+			remoteInfo = "Table Tool";
+		};
 		E1CC84F51B4A5F2A00ED8314 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E1CC84D31B4A5F2A00ED8314 /* Project object */;
@@ -46,6 +55,11 @@
 		36007A091D083BA000898043 /* Table Tool.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "Table Tool.entitlements"; sourceTree = "<group>"; };
 		5B338F721EF03D8000D40406 /* Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
 		5B338F731EF03D8000D40406 /* Constants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Constants.m; sourceTree = "<group>"; };
+		5BBE9AED1EF676D100FB2806 /* Table Tool UI Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Table Tool UI Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5BBE9AEF1EF676D100FB2806 /* Document_UI_Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Document_UI_Tests.m; sourceTree = "<group>"; };
+		5BBE9AF11EF676D100FB2806 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5BCD58231EF67D0F00A7382C /* NSFileHandle+TempFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSFileHandle+TempFile.h"; sourceTree = "<group>"; };
+		5BCD58241EF67D0F00A7382C /* NSFileHandle+TempFile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSFileHandle+TempFile.m"; sourceTree = "<group>"; };
 		AA41D3431CF2E7CE00CB3E7D /* Table Tool-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Table Tool-Bridging-Header.h"; sourceTree = "<group>"; };
 		AA58C3F81CFC4DC600106C66 /* TTFormatViewControllerAccessory.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TTFormatViewControllerAccessory.xib; sourceTree = "<group>"; };
 		AAB016711D057426005E3F7A /* Credits.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
@@ -85,6 +99,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		5BBE9AEA1EF676D100FB2806 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E1CC84D81B4A5F2A00ED8314 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -102,11 +123,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5BBE9AEE1EF676D100FB2806 /* Table Tool UI Tests */ = {
+			isa = PBXGroup;
+			children = (
+				5BCD58231EF67D0F00A7382C /* NSFileHandle+TempFile.h */,
+				5BCD58241EF67D0F00A7382C /* NSFileHandle+TempFile.m */,
+				5BBE9AEF1EF676D100FB2806 /* Document_UI_Tests.m */,
+				5BBE9AF11EF676D100FB2806 /* Info.plist */,
+			);
+			path = "Table Tool UI Tests";
+			sourceTree = "<group>";
+		};
 		E1CC84D21B4A5F2A00ED8314 = {
 			isa = PBXGroup;
 			children = (
 				E1CC84DD1B4A5F2A00ED8314 /* Table Tool */,
 				E1CC84F71B4A5F2A00ED8314 /* Table ToolTests */,
+				5BBE9AEE1EF676D100FB2806 /* Table Tool UI Tests */,
 				E1CC84DC1B4A5F2A00ED8314 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -116,6 +149,7 @@
 			children = (
 				E1CC84DB1B4A5F2A00ED8314 /* Table Tool.app */,
 				E1CC84F41B4A5F2A00ED8314 /* Table ToolTests.xctest */,
+				5BBE9AED1EF676D100FB2806 /* Table Tool UI Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -190,6 +224,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		5BBE9AEC1EF676D100FB2806 /* Table Tool UI Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5BBE9AF61EF676D100FB2806 /* Build configuration list for PBXNativeTarget "Table Tool UI Tests" */;
+			buildPhases = (
+				5BBE9AE91EF676D100FB2806 /* Sources */,
+				5BBE9AEA1EF676D100FB2806 /* Frameworks */,
+				5BBE9AEB1EF676D100FB2806 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5BBE9AF31EF676D100FB2806 /* PBXTargetDependency */,
+			);
+			name = "Table Tool UI Tests";
+			productName = "Table Tool UI Tests";
+			productReference = 5BBE9AED1EF676D100FB2806 /* Table Tool UI Tests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		E1CC84DA1B4A5F2A00ED8314 /* Table Tool */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E1CC84FE1B4A5F2A00ED8314 /* Build configuration list for PBXNativeTarget "Table Tool" */;
@@ -235,6 +287,11 @@
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Egger Apps";
 				TargetAttributes = {
+					5BBE9AEC1EF676D100FB2806 = {
+						CreatedOnToolsVersion = 8.2.1;
+						ProvisioningStyle = Automatic;
+						TestTargetID = E1CC84DA1B4A5F2A00ED8314;
+					};
 					E1CC84DA1B4A5F2A00ED8314 = {
 						CreatedOnToolsVersion = 6.4;
 						SystemCapabilities = {
@@ -264,11 +321,19 @@
 			targets = (
 				E1CC84DA1B4A5F2A00ED8314 /* Table Tool */,
 				E1CC84F31B4A5F2A00ED8314 /* Table ToolTests */,
+				5BBE9AEC1EF676D100FB2806 /* Table Tool UI Tests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		5BBE9AEB1EF676D100FB2806 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E1CC84D91B4A5F2A00ED8314 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -297,6 +362,15 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		5BBE9AE91EF676D100FB2806 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5BCD58251EF67D0F00A7382C /* NSFileHandle+TempFile.m in Sources */,
+				5BBE9AF01EF676D100FB2806 /* Document_UI_Tests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E1CC84D71B4A5F2A00ED8314 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -326,6 +400,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		5BBE9AF31EF676D100FB2806 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E1CC84DA1B4A5F2A00ED8314 /* Table Tool */;
+			targetProxy = 5BBE9AF21EF676D100FB2806 /* PBXContainerItemProxy */;
+		};
 		E1CC84F61B4A5F2A00ED8314 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = E1CC84DA1B4A5F2A00ED8314 /* Table Tool */;
@@ -353,6 +432,36 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		5BBE9AF41EF676D100FB2806 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "Table Tool UI Tests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "at.eggerapps.Table-Tool-UI-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = "Table Tool";
+			};
+			name = Debug;
+		};
+		5BBE9AF51EF676D100FB2806 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "Table Tool UI Tests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "at.eggerapps.Table-Tool-UI-Tests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_TARGET_NAME = "Table Tool";
+			};
+			name = Release;
+		};
 		E1CC84FC1B4A5F2A00ED8314 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -509,6 +618,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		5BBE9AF61EF676D100FB2806 /* Build configuration list for PBXNativeTarget "Table Tool UI Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5BBE9AF41EF676D100FB2806 /* Debug */,
+				5BBE9AF51EF676D100FB2806 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		E1CC84D61B4A5F2A00ED8314 /* Build configuration list for PBXProject "Table Tool" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Table Tool/CSVHeuristic.m
+++ b/Table Tool/CSVHeuristic.m
@@ -142,11 +142,12 @@
 
 -(void)checkForRowLengthsFromReader:(int)index{
     if(readLines.count == 0) return;
-    long count = ((NSArray *)readLines[0]).count;
+    long cellCountOfFirstRow = ((NSArray *)readLines[0]).count;
     BOOL sameLength = YES;
     for(int i = 1; i < readLines.count; i++){
-        sameLength &= (((NSArray *)readLines[i]).count == count);
-        if(((NSArray *)readLines[i]).count <= count) scores[index] = [NSNumber numberWithInt:([scores[index] intValue] + 1)];
+        NSUInteger cellCount = ((NSArray *)readLines[i]).count;
+        sameLength &= (cellCount == cellCountOfFirstRow);
+        if (cellCount <= cellCountOfFirstRow) scores[index] = [NSNumber numberWithUnsignedInteger:([scores[index] intValue] + cellCount)];
     }
     if(sameLength){
         scores[index] = [NSNumber numberWithInt:([scores[index] intValue] + 5)];

--- a/Table Tool/CSVWriter.h
+++ b/Table Tool/CSVWriter.h
@@ -17,6 +17,7 @@
 
 -(instancetype)initWithDataArray:(NSArray *) dataArray columnsOrder:(NSArray *)columnsOrder configuration:(CSVConfiguration *)config;
 
+-(NSString *)writeString;
 -(NSData *)writeDataWithError:(NSError **) outError;
 
 @end

--- a/Table Tool/CSVWriter.m
+++ b/Table Tool/CSVWriter.m
@@ -25,7 +25,7 @@
     return self;
 }
 
--(NSData *)writeDataWithError:(NSError *__autoreleasing *)outError {
+-(NSString *)writeString {
     
     NSMutableString *dataString = [[NSMutableString alloc]init];
     
@@ -69,6 +69,12 @@
     }else{
         [dataString appendString:@""];
     }
+    
+    return dataString;
+}
+
+-(NSData *)writeDataWithError:(NSError *__autoreleasing *)outError {
+    NSString *dataString = [self writeString];
     
     NSData *finalData = [dataString dataUsingEncoding:_config.encoding];
     if(finalData == nil){

--- a/Table Tool/Constants.h
+++ b/Table Tool/Constants.h
@@ -1,0 +1,13 @@
+//
+//  Constants.h
+//  Table Tool
+//
+//  Created by Martin Koehler on 12.06.17.
+//  Copyright (c) 2017 Egger Apps. All rights reserved.
+//
+
+#include <Cocoa/Cocoa.h>
+
+#pragma mark Pasteboard Types
+
+extern NSString *TTRowInternalPboardType;

--- a/Table Tool/Constants.m
+++ b/Table Tool/Constants.m
@@ -1,0 +1,13 @@
+//
+//  Constants.h
+//  Table Tool
+//
+//  Created by Martin Koehler on 12.06.17.
+//  Copyright (c) 2017 Egger Apps. All rights reserved.
+//
+
+#include "Constants.h"
+
+#pragma mark Initializing Globals for Pasteboard Types
+
+NSString *TTRowInternalPboardType = @"Table Tool Row Internal PasteBoard Type";


### PR DESCRIPTION
* added drag and drop support for the document table view
* using drag and drop, (single and multiple selections of) table view rows can now be moved
* dragged table view rows are now also placed in the NSPasteBoard in textual CSV form (enables dropping into other applications)