### PR TITLE
Performance Optimizations

### DIFF
--- a/Table Tool/CSVHeuristic.h
+++ b/Table Tool/CSVHeuristic.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import "CSVConfiguration.h"
+#import "CSVReader.h"
 
 @interface CSVHeuristic : NSObject
 
@@ -26,7 +27,7 @@
 @property BOOL preferChineseEncoding;
 
 -(instancetype)initWithData:(NSData *)data;
--(CSVConfiguration *)calculatePossibleFormat;
+-(CSVReader *)calculatePossibleFormat;
 -(void)setEncoding:(NSStringEncoding)encoding;
 
 @end

--- a/Table Tool/CSVHeuristic.m
+++ b/Table Tool/CSVHeuristic.m
@@ -107,7 +107,7 @@
 	}
 }
 
--(CSVConfiguration *)calculatePossibleFormat{
+-(CSVReader *)calculatePossibleFormat{
     [self initializeArrays];
 	NSArray *encodingTestList;
 	if (self.preferChineseEncoding) {
@@ -133,7 +133,7 @@
         }
     }
     
-    return [self getBestConfiguration];
+    return [self getBestReader];
 }
 
 -(BOOL)useSimpleHeuristic{
@@ -190,7 +190,7 @@
     scores[index] = [NSNumber numberWithInt:([scores[index] intValue] + numbers)];
 }
 
--(CSVConfiguration *)getBestConfiguration{
+-(CSVReader *)getBestReader{
     NSNumber *highestScore = scores[0];
     int highestScoreIndex = 0;
     for(int i = 1; i < readerArray.count; i++){
@@ -200,10 +200,10 @@
             highestScoreIndex = i;
         }
     }
-    CSVConfiguration *finalConfig = ((CSVReader *)readerArray[highestScoreIndex]).config;
-    finalConfig.firstRowAsHeader = [firstRowArray[highestScoreIndex] boolValue];
-    
-    return finalConfig;
+    CSVReader *bestReader = readerArray[highestScoreIndex];
+    bestReader.config.firstRowAsHeader = [firstRowArray[highestScoreIndex] boolValue];
+
+    return bestReader;
 }
 
 @end

--- a/Table Tool/CSVReader.m
+++ b/Table Tool/CSVReader.m
@@ -8,8 +8,34 @@
 
 #import "CSVReader.h"
 
+@interface CSVScanner : NSObject
++ (instancetype)scannerWithString:(NSString *)string;
+
+@property (nonatomic, copy) NSString *string;
+@property (nonatomic) NSUInteger scanLocation;
+@property (nonatomic, readonly, getter=isAtEnd) BOOL atEnd;
+
+@end
+
+@implementation CSVScanner
+
++ (instancetype)scannerWithString:(NSString *)string
+{
+    CSVScanner *scanner = [[CSVScanner alloc] init];
+    scanner.string = string;
+    return scanner;
+}
+
+- (BOOL)isAtEnd
+{
+    return _scanLocation == _string.length;
+}
+
+@end
+
+
 @interface CSVReader () {
-    NSScanner *dataScanner;
+    CSVScanner *dataScanner;
     NSString *dataString;
 	NSMutableCharacterSet *newlineCharacterSet;
 	NSMutableCharacterSet *quoteEndedCharacterSet;
@@ -66,10 +92,8 @@
             }
             return NO;
         }
-        dataScanner = [NSScanner scannerWithString:dataString];
-        dataScanner.caseSensitive = YES;
-        dataScanner.charactersToBeSkipped = nil;
-        
+        dataScanner = [CSVScanner scannerWithString:dataString];
+
 		newlineCharacterSet = [NSCharacterSet newlineCharacterSet].mutableCopy;
 		[newlineCharacterSet removeCharactersInString:@"\x0b\x0c"];
         quoteEndedCharacterSet = newlineCharacterSet.mutableCopy;

--- a/Table Tool/CSVReader.m
+++ b/Table Tool/CSVReader.m
@@ -12,6 +12,7 @@
 + (instancetype)scannerWithString:(NSString *)string;
 
 @property (nonatomic, copy) NSString *string;
+@property (nonatomic) NSUInteger stringLength;
 @property (nonatomic) NSUInteger scanLocation;
 @property (nonatomic, readonly, getter=isAtEnd) BOOL atEnd;
 
@@ -23,12 +24,13 @@
 {
     CSVScanner *scanner = [[CSVScanner alloc] init];
     scanner.string = string;
+    scanner.stringLength = string.length;
     return scanner;
 }
 
 - (BOOL)isAtEnd
 {
-    return _scanLocation == _string.length;
+    return _scanLocation == _stringLength;
 }
 
 @end

--- a/Table Tool/CSVReader.m
+++ b/Table Tool/CSVReader.m
@@ -203,13 +203,13 @@
     if([dataString characterAtIndex:dataScanner.scanLocation] != '\"'){
         return NO;
     }
-    
-    NSMutableString *temporaryString = [[NSMutableString alloc] init];
+
     dataScanner.scanLocation++;
-    
+    NSRange stringRange = NSMakeRange(dataScanner.scanLocation, 0);
+
     while(!dataScanner.isAtEnd){
         while(!dataScanner.isAtEnd && ![quoteAndEscapeSet characterIsMember:[dataString characterAtIndex:dataScanner.scanLocation]]){
-            [temporaryString appendString:[dataString substringWithRange:NSMakeRange(dataScanner.scanLocation, 1)]];
+            stringRange.length++;
             dataScanner.scanLocation++;
         }
         
@@ -224,7 +224,7 @@
             if([_config.escapeCharacter isEqualToString:_config.quoteCharacter]){
                 if((dataScanner.scanLocation+2 <= dataString.length && [quoteEndedCharacterSet characterIsMember:[dataString characterAtIndex:dataScanner.scanLocation+1]]) || dataScanner.scanLocation+1 == dataString.length){
                     dataScanner.scanLocation++;
-                    *scannedString = temporaryString;
+                    *scannedString = [dataScanner.string substringWithRange:stringRange];
                     [self checkForCRLF];
                     return YES;
                 }
@@ -237,7 +237,7 @@
                 }
                 return NO;
             }
-            [temporaryString appendString:[dataString substringWithRange:NSMakeRange(dataScanner.scanLocation,1)]];
+            stringRange.length++;
             dataScanner.scanLocation++;
             continue;
         }
@@ -245,7 +245,7 @@
         if([dataString characterAtIndex:dataScanner.scanLocation] == [_config.quoteCharacter characterAtIndex:0]) {
             dataScanner.scanLocation++;
             if(dataScanner.isAtEnd || [quoteEndedCharacterSet characterIsMember:[dataString characterAtIndex:dataScanner.scanLocation]]){
-                *scannedString = temporaryString;
+                *scannedString = [dataScanner.string substringWithRange:stringRange];
                 [self checkForCRLF];
                 return YES;
             }
@@ -264,7 +264,7 @@
 
 -(BOOL)scanUnquotedValueIntoString:(NSString **)scannedString error:(NSError **)outError{
     
-    NSMutableString *temporaryString = [[NSMutableString alloc]initWithString:@""];
+    NSRange stringRange = NSMakeRange(dataScanner.scanLocation, 0);
     while(!dataScanner.isAtEnd && ![quoteEndedCharacterSet characterIsMember:[dataString characterAtIndex:dataScanner.scanLocation]]){
         if([dataString characterAtIndex:dataScanner.scanLocation] == '\"' && !unquoted){
             if(outError != NULL) {
@@ -272,10 +272,10 @@
             }
             return NO;
         }
-        [temporaryString appendString:[dataString substringWithRange:NSMakeRange(dataScanner.scanLocation, 1)]];
+        stringRange.length++;
         dataScanner.scanLocation++;
     }
-    *scannedString = temporaryString;
+    *scannedString = [dataScanner.string substringWithRange:stringRange];
     [self checkForCRLF];
     return YES;
 }

--- a/Table Tool/CSVReader.m
+++ b/Table Tool/CSVReader.m
@@ -87,9 +87,8 @@
         
         if(!dataString){
             dataString = [[NSString alloc] initWithData:_data encoding:_config.encoding];
-            CDataString = [dataString cStringUsingEncoding:_config.encoding];
         }
-        
+        CDataString = [dataString cStringUsingEncoding:_config.encoding];
         if(!dataString) {
             if(outError != NULL) {
                 *outError = [NSError errorWithDomain:@"at.eggerapps.Table-Tool" code:1 userInfo: @{NSLocalizedDescriptionKey: @"Could not read data", NSLocalizedRecoverySuggestionErrorKey:@"Try specifying a different encoding."}];

--- a/Table Tool/Document.h
+++ b/Table Tool/Document.h
@@ -8,12 +8,14 @@
 
 #import <Cocoa/Cocoa.h>
 #import "CSVConfiguration.h"
+#import "CSVReader.h"
 #import "TTFormatViewController.h"
 
 @interface Document : NSDocument <NSTableViewDataSource, NSTableViewDelegate, TTFormatViewControllerDelegate>
 
 @property NSMutableArray *data;
 @property long maxColumnNumber;
+@property CSVReader *csvReader;
 @property CSVConfiguration *csvConfig;
 
 @property IBOutlet NSTableView *tableView;

--- a/Table Tool/Document.m
+++ b/Table Tool/Document.m
@@ -291,12 +291,13 @@
     
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:[NSString stringWithFormat:@"^\\s*[+-]?(\\d+\\%@?\\d*|\\d*\\%@?\\d+)([eE][+-]?\\d+)?\\s*$",self.csvConfig.decimalMark,self.csvConfig.decimalMark] options:0 error:NULL];
     NSString *userInputValue = (NSString *)object;
-    if([regex numberOfMatchesInString:userInputValue options:0 range:NSMakeRange(0, [userInputValue length])] == 1){
-        rowArray[tableColumn.identifier.integerValue] = [NSDecimalNumber decimalNumberWithString:userInputValue locale:@{NSLocaleDecimalSeparator:self.csvConfig.decimalMark}];
-    }else{
-        rowArray[tableColumn.identifier.integerValue] = userInputValue;
+    @autoreleasepool {
+        if([regex numberOfMatchesInString:userInputValue options:0 range:NSMakeRange(0, [userInputValue length])] == 1){
+            rowArray[tableColumn.identifier.integerValue] = [NSDecimalNumber decimalNumberWithString:userInputValue locale:@{NSLocaleDecimalSeparator:self.csvConfig.decimalMark}];
+        }else{
+            rowArray[tableColumn.identifier.integerValue] = userInputValue;
+        }
     }
-    
     _data[rowIndex] = rowArray;
     if (shouldReload) [self.tableView reloadData];
 }

--- a/Table Tool/Document.m
+++ b/Table Tool/Document.m
@@ -16,7 +16,6 @@
 
 @interface Document () {
     NSCell *dataCell;
-    NSData *savedData;
     NSArray *columnNames;
     
     NSError *readingError;
@@ -156,7 +155,7 @@
 
 -(BOOL)readFromURL:(NSURL *)url ofType:(NSString *)typeName error:(NSError * _Nullable __autoreleasing *)outError {
     [self.undoManager removeAllActions];
-	NSData *data = [NSData dataWithContentsOfURL:url options:0 error:outError];
+	NSData *data = [NSData dataWithContentsOfURL:url options:NSDataReadingMappedAlways | NSDataReadingUncached error:outError];
 	if (!data) {
 		return NO;
 	}
@@ -167,15 +166,16 @@
 		}
 	}
 	NSStringEncoding usedEncoding;
-	if ([[NSString alloc] initWithContentsOfURL:url usedEncoding:&usedEncoding error:nil]) {
+    NSString *usedEncodingString = [[NSString alloc] initWithContentsOfURL:url usedEncoding:&usedEncoding error:nil];
+	if (usedEncodingString != nil) {
 		formatHeuristic.encoding = usedEncoding;
 	}
+
     newFile = NO;
-    self.csvConfig = [formatHeuristic calculatePossibleFormat];
-    
-    savedData = data;
-	
-	NSError *error = nil;
+    self.csvReader = [formatHeuristic calculatePossibleFormat];
+    self.csvConfig = self.csvReader.config;
+
+    NSError *error = nil;
 	if (![self reloadDataWithError:&error]) {
 		readingError = error;
 		if (dataCell) [self displayError:error];
@@ -191,8 +191,10 @@
 	[_data removeAllObjects];
 	
 	NSError *outError;
-	CSVReader *reader = [[CSVReader alloc ]initWithData:savedData configuration: self.csvConfig];
-	columnNames = nil;
+    CSVReader *reader = self.csvReader;
+    [reader reset];
+
+    columnNames = nil;
 	while(!reader.isAtEnd) {
 		NSArray *line = [reader readLineWithError:&outError];
 		if (!line) {

--- a/Table ToolTests/Table_ToolTests.m
+++ b/Table ToolTests/Table_ToolTests.m
@@ -250,7 +250,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-comma-separated-people-1" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], ',', "Column Separator should be ','.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], '.', "Decimal Mark should be '.'.");
     XCTAssertEqual([config.quoteCharacter characterAtIndex:0], '\"', "Quote should be enabled.");
@@ -262,7 +262,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-comma-separated-people-2" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], ',', "Column Separator should be ','.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], '.', "Decimal Mark should be '.'.");
     XCTAssertTrue(config.firstRowAsHeader, "First row should be header.");
@@ -273,7 +273,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-comma-separated-places" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], ',', "Column Separator should be ','.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], '.', "Decimal Mark should be '.'.");
     XCTAssert([config.quoteCharacter isEqual:@"\""], "Quote should be enabled.");
@@ -286,7 +286,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-config1" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], ',', "Column Separator should be ','.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], '.', "Decimal Mark should be '.'.");
     XCTAssertEqual([config.quoteCharacter characterAtIndex:0], '\"', "Quote should be enabled.");
@@ -299,7 +299,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-config2" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], ';', "Column Separator should be ';'.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], ',', "Decimal Mark should be ','.");
     XCTAssertEqual([config.quoteCharacter characterAtIndex:0], '\"', "Quote should be enabled.");
@@ -312,7 +312,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-config3" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], '\t', "Column Separator should be '\t'.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], '.', "Decimal Mark should be '.'.");
     XCTAssertEqual([config.quoteCharacter characterAtIndex:0], '\"', "Quote should be enabled.");
@@ -325,7 +325,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-config4" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], '\t', "Column Separator should be '\t'.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], ',', "Decimal Mark should be ','.");
     XCTAssertEqual([config.quoteCharacter characterAtIndex:0], '\"', "Quote should be enabled.");
@@ -338,7 +338,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-config5" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], ';', "Column Separator should be ';'.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], ',', "Decimal Mark should be ','.");
     XCTAssertEqual([config.quoteCharacter characterAtIndex:0], '\"', "Quote should be enabled.");
@@ -351,7 +351,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-config6" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], ',', "Column Separator should be ','.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], '.', "Decimal Mark should be '.'.");
     XCTAssertTrue([config.quoteCharacter isEqualToString:@""], "Quote should be disabled.");
@@ -364,7 +364,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-config7" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], ';', "Column Separator should be ';'.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], ',', "Decimal Mark should be ','.");
     XCTAssertTrue([config.quoteCharacter isEqualToString:@""], "Quote should be disabled.");
@@ -377,7 +377,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-config8" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], '\t', "Column Separator should be '\t'.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], '.', "Decimal Mark should be '.'.");
     XCTAssertTrue([config.quoteCharacter isEqualToString:@""], "Quote should be disabled.");
@@ -390,7 +390,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-config9" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], '\t', "Column Separator should be '\t'.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], ',', "Decimal Mark should be ','.");
     XCTAssertTrue([config.quoteCharacter isEqualToString:@""], "Quote should be disabled.");
@@ -403,7 +403,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-config10" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], ',', "Column Separator should be ','.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], '.', "Decimal Mark should be '.'.");
     XCTAssertEqual([config.quoteCharacter characterAtIndex:0], '\"', "Quote should be enabled.");
@@ -416,7 +416,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-config11" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual([config.columnSeparator characterAtIndex:0], ',', "Column Separator should be ','.");
     XCTAssertEqual([config.decimalMark characterAtIndex:0], ',', "Decimal Mark should be ','.");
     XCTAssertEqual([config.quoteCharacter characterAtIndex:0], '\"', "Quote should be enabled.");
@@ -428,7 +428,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-first-row-with-number" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertFalse(config.firstRowAsHeader, "First row should not be header");
 }
 
@@ -436,7 +436,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-first-row-one-row-shorter" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertFalse(config.firstRowAsHeader, "First row should not be header");
 }
 
@@ -444,7 +444,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-first-row-longer" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertFalse(config.firstRowAsHeader, "First row should not be header");
 }
 
@@ -452,7 +452,7 @@
     NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/heuristic-no-utf-encoding" withExtension:@"csv"];
     NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
     CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-    config = [heuristic calculatePossibleFormat];
+    config = [heuristic calculatePossibleFormat].config;
     XCTAssertEqual(config.encoding, NSWindowsCP1252StringEncoding, "Encoding should be Western");
 }
 
@@ -461,7 +461,7 @@
 	NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
 	CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
 	heuristic.preferChineseEncoding = YES;
-	config = [heuristic calculatePossibleFormat];
+	config = [heuristic calculatePossibleFormat].config;
 	XCTAssertEqual(config.encoding, CFStringConvertEncodingToNSStringEncoding(kCFStringEncodingGB_18030_2000), "Encoding should be GBK");
 }
 
@@ -469,7 +469,7 @@
 	NSURL *testFileUrl = [[NSBundle bundleForClass:[self class]] URLForResource:@"Heuristic Test Documents/issue-4-sample" withExtension:@"csv"];
 	NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileUrl];
 	CSVHeuristic *heuristic = [[CSVHeuristic alloc] initWithData:testData];
-	config = [heuristic calculatePossibleFormat];
+	config = [heuristic calculatePossibleFormat].config;
 	XCTAssertEqual(config.encoding, NSMacOSRomanStringEncoding);
 	XCTAssertEqualObjects(config.columnSeparator, @"\t");
 	XCTAssertTrue(config.firstRowAsHeader);
@@ -514,7 +514,7 @@
         for(int i = 0;i < 10; i++){
             NSData *testData = [[NSData alloc] initWithContentsOfURL:testFileURL];
             CSVHeuristic *heuristic = [[CSVHeuristic alloc]initWithData:testData];
-            config = [heuristic calculatePossibleFormat];
+            config = [heuristic calculatePossibleFormat].config;
             XCTAssertEqual([config.columnSeparator characterAtIndex:0], ',', "Column Separator should be ','.");
             XCTAssertEqual([config.decimalMark characterAtIndex:0], ',', "Decimal Mark should be ','.");
             XCTAssertEqual([config.quoteCharacter characterAtIndex:0], '\"', "Quote should be enabled.");


### PR DESCRIPTION
I've got a couple really big (20mb-80mb) CSV files that I need to open, and TableTool was a bit slow to load things. Spent an hour or two in Instruments.app and fixed some low-hanging fruit, and roughly grouped into two categories: CPU-savings and Memory-savings

All tests pass, so I don't think anything broke.

[ed: rough benchmarks discussed below were run on a MacBook Pro (13-inch, 2017, Four Thunderbolt 3 Ports) with a 3.3 GHz Intel Core i5 and 16 GB 2133 MHz LPDDR3)]
[ed2: I didn't look as closely but this cuts the time it takes to open the FL_insurance_sample.csv.zip file from #58 in half, from ~2.5s to ~1.25s]

#### CPU
- edc0504322893599e53a9f6005a23cddc3d0bb89 makes less temporary strings and instead tracks string ranges; this is a bulk of the improvement. _Estimated time for opening an 80mb CSV file goes from 25s to 8.5s_
- ae3f4ff86d72fb476807071dba5c4ad240e91cce stop using `NSScanner` and use a custom `CSVScanner` value type instead; TableTool isn't using any of the convenience that `NSScanner` has, and `NSScanner` does a lot under the hood to try and prepare for that (e.g.: with localization). _Estimated time for opening an 80mb CSV file goes from 8.5s to 5.5s_
- e12e1569490ab2d2810478545cc122352e323f8d track the C data string in `CSVReader` once and reference it instead of using `characterAtIndex:`. _Estimated time for opening an 80mb CSV file goes from 5.25s to 4.5s_
- b4ef60d5c9c93aac4a063ebec277043cd5ff7cd5 Cache the string length in `CSVScanner`; `NSString` is immutable and with an 80mb CSV file, this call adds up.  _Estimated time for opening an 80mb CSV file goes from 5.5s to 5.25s_. Bit of a microptimization but still notable enough.

#### Memory
- f369f3063ccf2ec7b9cdf7d9dc5b085b3c6d9a96 add an inner autoreleasepool around regex matching. `NSRegularExpression` uses `icu` under the hood which allocates a lot of things, but they don't need to live for very long. _Estimated memory optimizations impact: reduced peak memory usage for opening the 80mb CSV file from ~2.15GB to ~1.25gb._

#### Both
- 97e3e5de1b8360059b61460b62e1be8ab9609279 re-use `CSVReader`s that the heuristic creates when scanning the document; this avoids data copies and re-doing work to create new `NSString` objects in memory. _Estimated memory optimizations impact: reduced peak memory usage for opening the 80mb CSV file from ~1.25GB to ~925gb. Estimated time impact: reducing memory overhead saves another second and the 80mb CSV file takes ~3.5s to opening_